### PR TITLE
Bump actions/setup-dotnet to v4.

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         global-json-file: ./global.json
     - name: Setup Node.js


### PR DESCRIPTION
I want to update actions/setup-dotnet manually because its updates are not being detected for some reason.