### PR TITLE
Enable test:MSBuildCracker to avoid generating temporary csproj. (now it cannot generate lockfile so I remove the lockfile configuration before)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "postinstall": "dotnet tool restore",
     "build-css": "sass --style=compressed --no-source-map ./sass/style.scss ./docs/blog-fable/css/style.css",
     "serve": "dotnet fsi ./dev-server.fsx /blog-fable",
-    "build-fable": "dotnet fable src --runScript",
+    "build-fable": "dotnet fable src --test:MSBuildCracker --runScript",
     "build": "npm run build-css && npm run build-fable",
     "dev": "npm run build dev && npm run serve",
     "build-md": "node ./src/App.fs.js"


### PR DESCRIPTION
[Fable/src/Fable.Cli/CHANGELOG.md at 98bf8288b154cbae4ebfc29db79ad9ac163906e1 · fable-compiler/Fable](https://github.com/fable-compiler/Fable/blob/98bf8288b154cbae4ebfc29db79ad9ac163906e1/src/Fable.Cli/CHANGELOG.md?plain=1#L84)


[Fable/src/Fable.Compiler/MSBuildCrackerResolver.fs at 98bf8288b154cbae4ebfc29db79ad9ac163906e1 · fable-compiler/Fable](https://github.com/fable-compiler/Fable/blob/98bf8288b154cbae4ebfc29db79ad9ac163906e1/src/Fable.Compiler/MSBuildCrackerResolver.fs#L110-L112)
The lockfile generation force-disabled for now.
